### PR TITLE
Can you consider supporting Windows? Minor fixes makes it work here.

### DIFF
--- a/clay/core.py
+++ b/clay/core.py
@@ -204,7 +204,7 @@ class Clay(object):
                 return utils.copy_if_has_change(path_in, path_out)
 
             try:
-                content = self.render.to_string(relpath_in, **self.settings)
+                content = self.render.to_string(relpath_in.replace('\\', '/'), **self.settings)
             except TemplateSyntaxError:
                 print '-- WARNING:', 'Syntax error while trying to process', \
                     utils.to_unicode(relpath_in), 'as a Jinja template.'

--- a/clay/p_coffee.py
+++ b/clay/p_coffee.py
@@ -13,7 +13,7 @@ from jinja2.ext import Extension
 from .utils import get_source, remove_file
 
 
-COMMAND = 'coffee'
+COMMAND = 'coffee.cmd'
 
 try:
     subprocess.check_output([COMMAND, '--version'])

--- a/clay/p_less.py
+++ b/clay/p_less.py
@@ -11,7 +11,7 @@ import subprocess
 from jinja2.ext import Extension
 
 
-COMMAND = 'lessc'
+COMMAND = 'lessc.cmd'
 
 try:
     subprocess.check_output([COMMAND, '--version'])

--- a/clay/utils.py
+++ b/clay/utils.py
@@ -36,12 +36,10 @@ def is_binary(filepath):
 def walk_dir(path, callback, ignore=None):
     ignore = ignore or ()
     for folder, subs, files in os.walk(path):
-        ffolder = os.path.relpath(folder, path)
         for filename in files:
             if filename.startswith(ignore):
                 continue
-            relpath = os.path.join(ffolder, filename) \
-                .lstrip('.').lstrip('/')
+            relpath = os.path.relpath(os.path.join(folder, filename), path)
             callback(relpath)
 
 


### PR DESCRIPTION
Can you please look at this commit and consider pulling it (or parts of it) to support Windows? There are only few nags that stop it, and using the fixes here I have it working for me successfully at the moment.
- fixed core/utils.py to use (hopefully) os independent code
- fixed path for rendering to use forward slash for jinja's benefit,
  probably better to fix it in Shake.
-  coffee.cmd and lessc.cmd work for me
