### PR TITLE
Schemaless URL for font import

### DIFF
--- a/clay.css
+++ b/clay.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Pacifico);
+@import url(//fonts.googleapis.com/css?family=Pacifico);
 /* Foundation
 ///////////// */
 * {


### PR DESCRIPTION
Loading the website over https (https://lucuma.github.io/Clay/, this is enforced using for instance HTTPS Everywhere) the title font is not loaded because modern browsers (Chrome) block javascript and css loaded over plain http when the page is loaded over https.
By using a schemaless URL, the stylesheet should be loaded with the correct protocol.
