### PR TITLE
Allow build command to use force option

### DIFF
--- a/clay/cli.py
+++ b/clay/cli.py
@@ -80,13 +80,15 @@ class ClayCLI(proper_cli.Cli):
         app = make_app(clay)
         app.run(host, port)
 
-    def build(self, source: str = ".") -> None:
+    def build(self, source: str = ".", force: bool = False) -> None:
         """Generates a static copy of the project in a `build` folder.
 
         Arguments:
         - source: Where to find the project. By default in the current folder.
+        - force: set to True to overwrite conflicting files.
         """
-        clay = Clay(source)
+
+        clay = Clay(source, force)
         clay.build()
         print("\n Done! You'll find a static version of your ")
         print(" project in the `build` folder.\n")

--- a/clay/main.py
+++ b/clay/main.py
@@ -83,10 +83,11 @@ EXCLUDE_PAGE_PATTERNS = (
 
 
 class Clay:
-    def __init__(self, source_path):
+    def __init__(self, source_path, force = False):
         self.source_path = Path(source_path).resolve()
         self.build_path = self.source_path / BUILD_FOLDER
         self.static_path = self.source_path / STATIC_FOLDER
+        self.force = force
         self.config = config = self.load_config()
 
         must_exclude = make_matcher(config["exclude"])
@@ -105,6 +106,7 @@ class Clay:
             dst=self.build_path,
             must_filter=self.must_filter,
             is_binary=self.is_binary,
+            force=self.force,
             static_folder=STATIC_FOLDER,
             globals_=globals_,
             filters_=JINJA_FILTERS,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,6 +19,15 @@ def test_render(dst):
     assert (dst / "build" / "test.txt").read_text().startswith(expected)
 
 
+def test_render_with_force_overwrite(dst):
+    (dst / "test.txt").write_text("test")
+    cli.build(source=dst)
+
+    (dst / "test.txt").write_text("meh")
+    cli.build(source=dst, force=True)
+
+    assert (dst / "build" / "test.txt").read_text() == "meh"
+
 def test_do_not_render_static(dst):
     text = "{{ now() }}"
     os.mkdir(dst / "static")


### PR DESCRIPTION
I want to script the build of a Clay app for deployment purposes. I had a few issues with that : https://github.com/lucuma/Clay/issues/34 . To solve it I need to use the force option, already present  in `utils/blueprint_renderer.py` line 139.

This PR is just this : allowing a force option to be passed to `$ clay build`.